### PR TITLE
Node.js 14

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: registry.gitlab.com/dealmore/dealmore-build-images/lambdaci:nodejs12.x
+    container: registry.gitlab.com/dealmore/dealmore-build-images/lambda:nodejs14.x
 
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
 
   test-integration:
     runs-on: ubuntu-latest
-    container: registry.gitlab.com/dealmore/dealmore-build-images/lambdaci:nodejs12.x
+    container: registry.gitlab.com/dealmore/dealmore-build-images/lambda:nodejs14.x
 
     services:
       s3:

--- a/buildimage.Dockerfile
+++ b/buildimage.Dockerfile
@@ -2,7 +2,7 @@
 # Since it is intended to run on Amazon Linux we need to install binaries
 # for the internally used sharp package that match this distribution
 
-FROM registry.gitlab.com/dealmore/dealmore-build-images/lambdaci:nodejs12.x
+FROM amazon/aws-sam-cli-emulation-image-nodejs14.x
 
 WORKDIR /app
 

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ module "image_optimizer" {
   function_name = random_id.function_name.hex
   description   = var.deployment_name
   handler       = "handler.handler"
-  runtime       = "nodejs12.x"
+  runtime       = "nodejs14.x"
   memory_size   = var.lambda_memory_size
   timeout       = var.lambda_timeout
   publish       = true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "jest --testTimeout=60000 e2e.*"
   },
   "devDependencies": {
-    "@dealmore/sammy": "^1.1.0",
+    "@dealmore/sammy": "^1.3.0",
     "@types/jest": "^26.0.20",
     "@types/mime": "^2.0.3",
     "@types/node": "^12.0.0",

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -7,6 +7,8 @@ import { s3PublicDir } from './utils/s3-public-dir';
 import { getLocalIpAddressFromHost } from './utils/host-ip-address';
 import { acceptAllFixtures } from './constants';
 
+const NODE_RUNTIME = 'nodejs14.x';
+
 describe('[e2e]', () => {
   const route = '/_next/image';
   const hostIpAddress = getLocalIpAddressFromHost();
@@ -43,7 +45,7 @@ describe('[e2e]', () => {
           imageOptimizer: {
             filename: 'dist.zip',
             handler: 'handler.handler',
-            runtime: 'nodejs12.x',
+            runtime: NODE_RUNTIME,
             memorySize: 1024,
             route,
             method: 'get',
@@ -166,7 +168,7 @@ describe('[e2e]', () => {
           imageOptimizer: {
             filename: 'dist.zip',
             handler: 'handler.handler',
-            runtime: 'nodejs12.x',
+            runtime: NODE_RUNTIME,
             memorySize: 1024,
             route,
             method: 'get',

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,10 +345,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@dealmore/sammy@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@dealmore/sammy/-/sammy-1.1.0.tgz#2ce4622b7872a4d4ab88ebe1769e57941d3506f6"
-  integrity sha512-LQJ3sTocHMaV6dz5jUaLzZTx7ZNDmDm3cwgN+tYT/A+LX/SDYbBDo8+jprM6bZxvnvHx0WfZBbMseD0ZojU5rg==
+"@dealmore/sammy@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@dealmore/sammy/-/sammy-1.3.0.tgz#dcc3be6804706679717d9848d28c809cdde92a0e"
+  integrity sha512-bzthk8faP/PAg5m1lO/VAlqYy+MEIn3AA+oQgXJQPJNQGjtu3zLqVAa69axocD6z5uZzDFZmsoheTP4wynM0+A==
   dependencies:
     aws-sdk "^2.771.0"
     get-port "^5.1.1"


### PR DESCRIPTION
Upgrades Lambda runtime to `nodejs14.x`.

Fixes #4.