### PR TITLE
fix: passthrough_behaviour complaining in newer versions of terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ module.exports = {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| aws | >= 3.28.0 |
+| aws | >= 3.30.0 |
 | random | >= 2.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.28.0 |
+| aws | >= 3.30.0 |
 | random | >= 2.3.0 |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ module "image_optimizer" {
 #########################
 module "api_gateway" {
   source  = "terraform-aws-modules/apigateway-v2/aws"
-  version = "0.8.0"
+  version = "0.11.0"
 
   name          = var.deployment_name
   description   = "Managed by Terraform-next.js image optimizer"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.28.0"
+      version = ">= 3.30.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Bumps the api gateway to version 0.11.0 which resolves the error that can be triggered on newer versions of terraform:

```
Error: expected passthrough_behavior to be one of [WHEN_NO_MATCH NEVER WHEN_NO_TEMPLATES], got
```

Associated PR and fix here: https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/pull/24