### PR TITLE
fix: use jest in node_modules rather than locally installed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   ],
   "scripts": {
     "build:local": "scripts/build-local.sh",
-    "test": "jest --testPathIgnorePatterns e2e.*",
-    "test:e2e": "jest --testTimeout=60000 e2e.*"
+    "test": "npx jest --testPathIgnorePatterns e2e.*",
+    "test:e2e": "npx jest --testTimeout=60000 e2e.*"
   },
   "devDependencies": {
     "@dealmore/sammy": "^1.3.0",


### PR DESCRIPTION
This tells the tests to use the locally installed version of jest as specified in package.json rather than a globally installed version (which version may differ from computer to computer).