### PR TITLE
Adds GitHub workflow to trigger a new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      # Do a full checkout (all branches)
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: dealmore/gh-action-terraform-module-release@v1
+        with:
+          upstream-branch: main
+          release-branch: release
+          release-tag: ${{ github.event.inputs.tag }}
+          exclude: '["lib/*", "test/*", "package.json", "yarn.lock"]'


### PR DESCRIPTION
This adds a new GitHub action that allows us to trigger a release as described in #11.

Fixes #11.