### PR TITLE
Bump aws-sdk from 2.804.0 to 2.880.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "typescript": "^4.1.3"
   },
   "resolutions": {
-    "aws-sdk": "2.804.0"
+    "aws-sdk": "2.880.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,10 +1053,10 @@ available-typed-arrays@^1.0.2:
   dependencies:
     array-filter "^1.0.0"
 
-aws-sdk@*, aws-sdk@2.804.0, aws-sdk@^2.771.0:
-  version "2.804.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.804.0.tgz#ff7e6f91b86b4878ec69e3de895c10eb8203fc4b"
-  integrity sha512-a02pZdjL06MunElAZPPEjpghOp/ZA+16f+t4imh1k9FCDpsNVQrT23HRq/PMvRADA5uZZRkYwX8r9o6oH/1RlA==
+aws-sdk@*, aws-sdk@2.880.0, aws-sdk@^2.771.0:
+  version "2.880.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.880.0.tgz#2198818f3b42bdd387e1898c8aab5fcca2409a36"
+  integrity sha512-/dBk3ejw22ED2edzGfmJB83KXDA4wLIw5Hb+2YMhly+gOWecvevy0tML2+YN/cmxyTy+wT0E0sM7fm1v7kmHtw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
AWS Lambda now uses `2.880.0`: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html